### PR TITLE
Add request timeout option to deal with unreliable vTiger APIs

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -46,6 +46,9 @@ class Session
     // HTTP Client instance
     protected $httpClient;
 
+    // request timeout in seconds
+    protected $requestTimeout;
+
     // Service URL to which client connects to
     protected $vtigerUrl = null;
     protected $wsBaseURL = null;
@@ -70,11 +73,13 @@ class Session
      * Class constructor
      * @param string $vtigerUrl  The URL of the remote WebServices server
      * @param string [$wsBaseURL = 'webservice.php']  WebServices base URL appended to vTiger root URL
+     * @param int $requestTimeout Number of seconds after which request times out
      */
-    public function __construct($vtigerUrl, $wsBaseURL = 'webservice.php')
+    public function __construct($vtigerUrl, $wsBaseURL = 'webservice.php', $requestTimeout = 0)
     {
         $this->vtigerUrl = self::fixVtigerBaseUrl($vtigerUrl);
         $this->wsBaseURL = $wsBaseURL;
+        $this->requestTimeout = $requestTimeout;
 
         // Gets target URL for WebServices API requests
         $this->httpClient = new Client([
@@ -232,10 +237,10 @@ class Session
         try {
             switch ($method) {
                 case 'GET':
-                    $response = $this->httpClient->get($this->wsBaseURL, [ 'query' => $requestData ]);
+                    $response = $this->httpClient->get($this->wsBaseURL, [ 'query' => $requestData, 'timeout' => $this->requestTimeout ]);
                     break;
                 case 'POST':
-                    $response = $this->httpClient->post($this->wsBaseURL, [ 'form_params' => $requestData ]);
+                    $response = $this->httpClient->post($this->wsBaseURL, [ 'form_params' => $requestData, 'timeout' => $this->requestTimeout ]);
                     break;
                 default:
                     throw new WSException("Unsupported request type {$method}");

--- a/src/WSClient.php
+++ b/src/WSClient.php
@@ -60,12 +60,13 @@ class WSClient
      * @param  string $secret  Access key token (shown on user's profile page) or password, depends on $loginMode
      * @param  integer [$loginMode = self::USE_ACCESSKEY|USE_PASSWORD]  Login mode, defaults to username + accessKey
      * @param string [$wsBaseURL = 'webservice.php']  WebServices base URL appended to vTiger root URL
+     * @param int Optional request timeout in seconds
      */
-    public function __construct($vtigerUrl, $username, $secret, $loginMode = self::USE_ACCESSKEY, $wsBaseURL = 'webservice.php')
+    public function __construct($vtigerUrl, $username, $secret, $loginMode = self::USE_ACCESSKEY, $wsBaseURL = 'webservice.php', $requestTimeout = 0)
     {
         $this->modules = new Modules($this);
         $this->entities = new Entities($this);
-        $this->session = new Session($vtigerUrl, $wsBaseURL);
+        $this->session = new Session($vtigerUrl, $wsBaseURL, $requestTimeout);
 
         $loginOK = false;
         switch ($loginMode) {


### PR DESCRIPTION
The client can be initialized with an optional `$requestTimeout` argument. This timeout is passed to the session handler and finally to the Guzzle Http client (see [Guzzle Docs](http://docs.guzzlephp.org/en/stable/request-options.html#timeout)).