### PR TITLE
Sync params

### DIFF
--- a/src/Entities.php
+++ b/src/Entities.php
@@ -240,9 +240,10 @@ class Entities
      * Sync will return a sync result object containing details of changes after modifiedTime
      * @param  integer [$modifiedTime = null]    The date of the first change
      * @param  string [$moduleName = null]   The name of the module / entity type
+     * @param  string [$syncType = null]   Sync type determines the scope of the query
      * @return array  Sync result object
      */
-    public function sync($modifiedTime = null, $moduleName = null)
+    public function sync($modifiedTime = null, $moduleName = null, $syncType = null)
     {
         $modifiedTime = (empty($modifiedTime))
             ? strtotime('today midnight')
@@ -254,6 +255,10 @@ class Entities
 
         if (!empty($moduleName)) {
             $requestData[ 'elementType' ] = $moduleName;
+        }
+
+        if ($syncType) {
+            $requestData[ 'syncType' ] = $syncType;
         }
 
         return $this->wsClient->invokeOperation('sync', $requestData, 'GET');

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -256,7 +256,7 @@ class Entities
             $requestData[ 'elementType' ] = $moduleName;
         }
 
-        return $this->wsClient->invokeOperation('sync', $requestData, true);
+        return $this->wsClient->invokeOperation('sync', $requestData, 'GET');
     }
 
     /**


### PR DESCRIPTION
The sync operation can return records from the whole application, or only those assigned to the querying user. This PR adds an optional 'syncType' parameter, which lets us explicitly choose the scope of the sync.