### PR TITLE
Allow query builder to use limit with offset

### DIFF
--- a/src/Entities.php
+++ b/src/Entities.php
@@ -212,11 +212,11 @@ class Entities
      * @param  string   $moduleName  The name of the module / entity type
      * @param  array    $params  Data used to find matching entries
      * @return array    $select  The list of fields to select (defaults to SQL-like '*' - all the fields)
-     * @return integer      $limit  limit the list of entries to N records (acts like LIMIT in SQL)
-     * @return integer    $count  limit query will be 'LIMIT m, n' m representing offset, n representing count
+     * @return integer  $limit   Limit the list of entries to N records (acts like LIMIT in SQL)
+     * @return integer  $offset  Integer values to specify the offset of the query
      * @return array  The array containing matching entries or false if nothing was found
      */
-    public function findMany($moduleName, array $params, array $select = [ ], $limit = 0, $count = null)
+    public function findMany($moduleName, array $params, array $select = [ ], $limit = 0, $offset = 0)
     {
         if (!is_array($params) || (!empty($params) && !is_assoc_array($params))) {
             throw new WSException(
@@ -226,7 +226,7 @@ class Entities
         }
 
         // Builds the query
-        $query = self::getQueryString($moduleName, $params, $select, $limit, $count);
+        $query = self::getQueryString($moduleName, $params, $select, $limit, $offset);
 
         // Run the query
         $records = $this->wsClient->runQuery($query);
@@ -271,19 +271,18 @@ class Entities
      * @static
      * @param  string   $moduleName  The name of the module / entity type
      * @param  array    $params  Data used to find matching entries
-     * @return string    $select  The list of fields to select (defaults to SQL-like '*' - all the fields)
-     * @return string      $limit  limit the list of entries to N records (acts like LIMIT in SQL)
-     * @return integer    $count  limit query will be 'LIMIT m, n' m representing offset, n representing count
+     * @return string   $select  The list of fields to select (defaults to SQL-like '*' - all the fields)
+     * @return integer  $limit   Limit the list of entries to N records (acts like LIMIT in SQL)
+     * @return integer  $offset  Integer values to specify the offset of the query
      * @return string   The query build out of the supplied parameters
      */
-    public static function getQueryString($moduleName, array $params, array $select = [ ], $limit = 0, $count = null)
+    public static function getQueryString($moduleName, array $params, array $select = [ ], $limit = 0, $offset = 0)
     {
         $criteria = array();
         $select = (empty($select)) ? '*' : implode(',', $select);
         $query = sprintf("SELECT %s FROM $moduleName", $select);
         
         if (!empty($params)) {
-                        
             foreach ($params as $param => $value) {
                 $criteria[ ] = "{$param} LIKE '{$value}'";
             }
@@ -291,12 +290,10 @@ class Entities
             $query .= sprintf(' WHERE %s', implode(" AND ", $criteria));
         }
 
-        if (intval($limit) > 0 && is_null($count)) {
-            $query .= sprintf(" LIMIT %s", intval($limit));
-        }
-
-        if (intval($limit) > 0 && !is_null($count) && intval($count) > 0) {
-            $query .= sprintf(" LIMIT %s, %s", intval($limit), intval($count));
+        if (intval($limit) > 0) {
+            $query .= (intval($offset) > 0))
+                ? sprintf(" LIMIT %s, %s", intval($offset), intval($limit));
+                : sprintf(" LIMIT %s", intval($limit));
         }
 
         return $query;


### PR DESCRIPTION
By default VTiger allow in Query operation set a limit for the records that you want to get, but in addition query will be enforced with implicit maximum limit of 100 records in VTiger 6 and 200 records in VTiger 7 per fetch.

So if you have a Query that match for 150 records in VTgier 6 you need to use de LIMIT statement with an offset and count to get in two steps all the 150 records:

1. "....... LIMIT 0, 100;"
2. "....... LIMIT 100, 100;"

https://www.vtiger.com/docs/rest-api-for-vtiger#/Query

This PR allow in Entities::findMany() and Entities::getQueryString() use the argument $count to use the limit with an offset and count.

PD: Sorry for my English.